### PR TITLE
removed symlink

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,6 @@
 # Container image that runs your code
 FROM mcr.microsoft.com/powershell:latest as base
 
-#Symlink to the version of PowerShell we're targeting
-RUN ln -s /opt/microsoft/powershell/7/pwsh /bin/pwsh
-
 #Create custom rules dir
 RUN mkdir /custom_rules
 


### PR DESCRIPTION
Container fails to build now looks like this was fixed on the base image so the symlink isn't needed anymore